### PR TITLE
Fix like ajax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ build-iPhoneSimulator/
 /db/fixtures/development
 sample.md/
 public/uploads/category/image
+public/uploads/user/image/

--- a/app/assets/stylesheets/side/modules/botton.scss
+++ b/app/assets/stylesheets/side/modules/botton.scss
@@ -503,14 +503,14 @@
   }
 }
 
-#thanks-btn{
+.thanks-btn{
   font-size:x-small;
   color: #00a4bb;
   background-color: white;
   border:1px solid  #00a4bb;
   cursor: pointer;
 }
-#thanks-btn-aledy{
+.thanks-btn-aledy{
   font-size:x-small;
   color: white;
   background-color: #00a4bb;
@@ -518,7 +518,7 @@
   border: none;
 }
 
-#bad-btn{
+.bad-btn{
   border: none !important;
   color: gray;
   background-color: inherit;
@@ -527,7 +527,7 @@
   cursor: pointer;
   margin-left: 4px;
 }
-#bad-btn-aledy{
+.bad-btn-aledy{
   font-size:x-small;
   background-color:red;
   border: none;

--- a/app/assets/stylesheets/vertical/modules/botton.scss
+++ b/app/assets/stylesheets/vertical/modules/botton.scss
@@ -510,14 +510,14 @@
   }
 }
 
-#thanks-btn{
+.thanks-btn{
   font-size:x-small;
   color: #00a4bb;
   background-color: white;
   border:1px solid  #00a4bb;
   cursor: pointer;
 }
-#thanks-btn-aledy{
+.thanks-btn-aledy{
   font-size:x-small;
   color: white;
   background-color: #00a4bb;
@@ -525,7 +525,7 @@
   border: none;
 }
 
-#bad-btn{
+.bad-btn{
   border: none !important;
   color: gray;
   background-color: inherit;
@@ -534,7 +534,7 @@
   cursor: pointer;
   margin-left: 4px;
 }
-#bad-btn-aledy{
+.bad-btn-aledy{
   font-size:x-small;
   background-color:red;
   border: none;

--- a/app/controllers/bads_controller.rb
+++ b/app/controllers/bads_controller.rb
@@ -1,6 +1,6 @@
 class BadsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_message
+  before_action :set_variables
 
   def create
     Bad.create(user_id: params[:user_id], message_id: params[:message_id])
@@ -14,8 +14,9 @@ class BadsController < ApplicationController
   end
 
   private
-  def set_message
+  def set_variables
     @message = Message.find(params[:message_id])
+    @id_name = "#bad-btn-#{@message.id}"
   end
 
 end

--- a/app/controllers/thanks_controller.rb
+++ b/app/controllers/thanks_controller.rb
@@ -1,6 +1,6 @@
 class ThanksController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_message
+  before_action :set_variables
 
   def create
     Thank.create(user_id: params[:user_id], message_id: params[:message_id])
@@ -14,8 +14,9 @@ class ThanksController < ApplicationController
   end
 
   private
-  def set_message
+  def set_variables
     @message = Message.find(params[:message_id])
+    @id_name = "#thanks-btn-#{@message.id}"
   end
 
 end

--- a/app/controllers/user_chat_rooms_controller.rb
+++ b/app/controllers/user_chat_rooms_controller.rb
@@ -16,7 +16,7 @@ class UserChatRoomsController < ApplicationController
     @nil_message_room_id = @current_chat_rooms - @messages               #２つの配列の差分確認のみ渡す
     UserChatRoom.where(chat_room_id: @nil_message_room_id).destroy_all            #UserChatRoomレコードの削除
     # 自分以外の反映
-    @another_rooms = UserChatRoom.where(chat_room_id: my_chat_room_ids).where('user_id != ?', current_user.id).limit(30).order(updated_at: "ASC")
+    @another_rooms = UserChatRoom.where(chat_room_id: my_chat_room_ids).where('user_id != ?', current_user.id).limit(30).order(updated_at: "DESC")
     end
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -3,7 +3,7 @@ class Topic < ApplicationRecord
 
   belongs_to :category
   belongs_to :user
-  has_many :chat_rooms
+  has_many :chat_rooms, dependent: :destroy
   has_one :close
 
   validates :title, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,9 @@ class User < ApplicationRecord
 
   has_many :messages
   has_many :topics
-  has_many :chat_rooms
+  has_many :chat_rooms, through: :user_chat_room
   has_many :user_chat_rooms
-  has_many :thanks, dependent: :delete_all
-  has_many :bads, dependent: :delete_all
+  has_many :thanks, dependent: :destroy
+  has_many :bads, dependent: :destroy
 
 end

--- a/app/views/bads/_bad.haml
+++ b/app/views/bads/_bad.haml
@@ -1,6 +1,7 @@
-- if message.bad.blank? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
-  #bad-btn
-    = link_to '不適切な返信', user_message_bads_path(user_id: message.user_id, message_id: message.id), method: :post, data: { confirm: '本当によろしいですか?' }, remote: true
-- elsif message.bad.present? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
-  #bad-btn-aledy
-    = link_to '&#10003; 不適切な返信'.html_safe, user_message_bad_path(user_id: message.user_id, message_id: message.id, id: message.bad.id), method: :delete, data: { confirm: '不適切な返信を解除します' }, remote: true
+.bad-ajax{:id => "bad-btn-#{message.id}"}
+  - if message.bad.blank? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
+    .bad-btn
+      = link_to '不適切な返信', user_message_bads_path(user_id: message.user_id, message_id: message.id), method: :post, data: { confirm: '本当によろしいですか?' }, remote: true
+  - elsif message.bad.present? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
+    .bad-btn-aledy
+      = link_to '&#10003; 不適切な返信'.html_safe, user_message_bad_path(user_id: message.user_id, message_id: message.id, id: message.bad.id), method: :delete, data: { confirm: '不適切な返信を解除します' }, remote: true

--- a/app/views/bads/bad_ajax.js.erb
+++ b/app/views/bads/bad_ajax.js.erb
@@ -1,1 +1,1 @@
-$("#bad_button").html("<%= escape_javascript(render partial: 'bads/bad', locals: {message: @message}) %>");
+$("<%= @id_name %>").html("<%= escape_javascript(render partial: 'bads/bad', locals: {message: @message}) %>");

--- a/app/views/chat_rooms/_bad.haml
+++ b/app/views/chat_rooms/_bad.haml
@@ -1,6 +1,0 @@
-- if message.bad.blank? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
-  #bad-btn
-    = link_to '不適切な返信', user_message_bads_path(user_id: message.user_id, message_id: message.id), method: :post, data: { confirm: '本当によろしいですか?' }, remote: true
-- elsif message.bad.present? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
-  #bad-btn-aledy
-    = link_to '&#10003; 不適切な返信'.html_safe, user_message_bad_path(user_id: message.user_id, message_id: message.id), method: :delete, data: { confirm: '不適切な返信を解除します' }, remote: true

--- a/app/views/chat_rooms/show.haml
+++ b/app/views/chat_rooms/show.haml
@@ -24,9 +24,11 @@
                 = simple_format(message.content)
             .message-box__evaluation-flame
               #thanks_button
-                = render partial: 'thanks/thank', locals: { message: message }
+                = render 'thanks/thank', message: message
+                -# = render partial: 'thanks/thank', locals: { message: message }
               #bad_button
-                = render partial: 'bads/bad', locals: { message: message }
+                = render 'bads/bad', message: message
+                -# = render partial: 'bads/bad', locals: { message: message }
             - if message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
               %p.thanks-info ※ 評価は相手からは見えません　
     .message-container__input

--- a/app/views/shared/_top-page-header.haml
+++ b/app/views/shared/_top-page-header.haml
@@ -4,8 +4,6 @@
     .top-page__title
       %a{href: root_path}
         %h4 soudan
-    -# .red-btn
-    -#   今すぐ検索
     - unless user_signed_in?
       -# .white-line-btn
       -#   %a{href: new_user_registration_path}ユーザー登録

--- a/app/views/thanks/_thank.haml
+++ b/app/views/thanks/_thank.haml
@@ -1,6 +1,7 @@
-- if message.thank.blank? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
-  #thanks-btn
-    = link_to 'ありがとう', user_message_thanks_path(user_id: message.user_id, message_id: message.id), method: :post, remote: true
-- elsif message.thank.present? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
-  #thanks-btn-aledy
-    = link_to '&#10003; ありがとう'.html_safe, user_message_thank_path(user_id: message.user_id, message_id: message.id, id: message.thank.id), method: :delete, remote: true
+.thank-ajax{:id => "thanks-btn-#{message.id}"}
+    - if message.thank.blank? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
+        .thanks-btn
+            = link_to 'ありがとう', user_message_thanks_path(user_id: message.user_id, message_id: message.id), method: :post, remote: true
+    - elsif message.thank.present? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
+        .thanks-btn-aledy
+            = link_to '&#10003; ありがとう'.html_safe, user_message_thank_path(user_id: message.user_id, message_id: message.id, id: message.thank.id), method: :delete, remote: true

--- a/app/views/thanks/thank_ajax.js.erb
+++ b/app/views/thanks/thank_ajax.js.erb
@@ -1,1 +1,1 @@
-$("#thanks_button").html("<%= escape_javascript(render partial: 'thanks/thank', locals: {message: @message}) %>");
+$("<%= @id_name %>").html("<%= escape_javascript(render partial: 'thanks/thank', locals: {message: @message}) %>");

--- a/app/views/topics/_topic-box.haml
+++ b/app/views/topics/_topic-box.haml
@@ -17,6 +17,9 @@
             #{topic.category.name}
           .topic-box__inner__right__info__messanger
             .topic-box__inner__right__info__messanger__user
-              #{topic.user.name}
+              - if topic.user.nil?
+                退会済みユーザー
+              - else
+                #{topic.user.name}
             .topic-box__inner__right__info__messanger__time
               = time_ago_in_words(topic.created_at)+"前"

--- a/app/views/topics/show.haml
+++ b/app/views/topics/show.haml
@@ -5,9 +5,13 @@
       .topic-show-box__inner__top
         .topic-show-box__flex-box
           .topic-show-box__inner__user-icon
-            = image_tag @topic.user.image
+            - if @topic.user.present?
+              = image_tag @topic.user.image
           .topic-show-box__inner__user-name
-            #{@topic.user.name}
+            - if @topic.user.present?
+              #{@topic.user.name}
+            - else
+              退会済みユーザー
         .topic-show-box__inner__title
           #{@topic.title}
       .topic-show-box__inner__bottom

--- a/app/views/user_chat_rooms/index.haml
+++ b/app/views/user_chat_rooms/index.haml
@@ -12,14 +12,19 @@
               .mail-box__inner
                 .mail-box__inner__left
                   .topic-show-box__inner__user-icon
-                    = image_tag e.user.image
+                    - if e.user.present?
+                      = image_tag e.user.image
+                    - else
                 .mail-box__inner__right
                   .mail-box__info
                     -# .mail-box__info__topic_title 相談トッピック名 : #{e.chat_room.topic.title}
                     .mail-box__info__send-user-name
                       %strong
+                      - if e.user.present?
                         = e.user.name
                         さん
+                      - else
+                        退会済みユーザー
                     .mail-box__info__send-time
                       = time_ago_in_words(e.chat_room.messages.first.created_at)+"前"
                   .mail-last-message

--- a/db/migrate/4_create_topics.rb
+++ b/db/migrate/4_create_topics.rb
@@ -2,7 +2,7 @@ class CreateTopics < ActiveRecord::Migration[5.1]
   def change
     create_table :topics, id: false do |t|
       t.string :id, limit: 36, null: false, primary_key: true
-      t.references :user, type: :string, foreign_key: true
+      t.string :user_id
       t.string :title, null: false
       t.integer :category_id, null: false
       t.text :text, null: false

--- a/db/migrate/5_create_chat_rooms.rb
+++ b/db/migrate/5_create_chat_rooms.rb
@@ -2,7 +2,7 @@ class CreateChatRooms < ActiveRecord::Migration[5.1]
   def change
     create_table :chat_rooms, id: false do |t|
       t.string :id, limit: 36, null: false, primary_key: true
-      t.references :topic, type: :string, foreign_key: true
+      t.string :topic_id
       t.string :topic_create_user_id
       t.string :sender_user_id
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190519034508) do
+ActiveRecord::Schema.define(version: 20190519005353) do
 
   create_table "bads", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "user_id"
@@ -39,24 +39,12 @@ ActiveRecord::Schema.define(version: 20190519034508) do
     t.string "sender_user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["topic_id"], name: "index_chat_rooms_on_topic_id"
   end
 
   create_table "closes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "topic_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "friendly_id_slugs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "slug", null: false
-    t.integer "sluggable_id", null: false
-    t.string "sluggable_type", limit: 50
-    t.string "scope"
-    t.datetime "created_at"
-    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, length: { slug: 70, scope: 70 }
-    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", length: { slug: 140 }
-    t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
   end
 
   create_table "messages", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -92,7 +80,6 @@ ActiveRecord::Schema.define(version: 20190519034508) do
     t.text "text", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_topics_on_user_id"
   end
 
   create_table "user_chat_rooms", id: :string, limit: 36, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -132,6 +119,4 @@ ActiveRecord::Schema.define(version: 20190519034508) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
-  add_foreign_key "chat_rooms", "topics"
-  add_foreign_key "topics", "users"
 end

--- a/db/seeds/user.rb
+++ b/db/seeds/user.rb
@@ -1,7 +1,7 @@
 
 # #Userモデル
-# User.create!([
-#   {name: 'ユーザー１', image: open("#{Rails.root}/db/fixtures/images/users/user_1.png"), email: 'a@test.com', password: '111111', },
-#   {name: 'ユーザー２', image: open("#{Rails.root}/db/fixtures/images/users/user_2.png"), email: 'b@test.com', password: '111111', },
-#   {name: 'ユーザー３', image: open("#{Rails.root}/db/fixtures/images/users/user_3.png"), email: 'c@test.com', password: '111111', },
-# ])
+User.create!([
+  {name: 'ユーザー１', image: open("#{Rails.root}/db/fixtures/images/users/user_1.png"), email: 'a@test.com', password: '111111', },
+  {name: 'ユーザー２', image: open("#{Rails.root}/db/fixtures/images/users/user_2.png"), email: 'b@test.com', password: '111111', },
+  {name: 'ユーザー３', image: open("#{Rails.root}/db/fixtures/images/users/user_3.png"), email: 'c@test.com', password: '111111', },
+])


### PR DESCRIPTION
### 更新内容
- 変更前
thanksボタンを押した際、ajax通信で帰ってくるview中のthanksボタンのpathがきちんと指定されて反映されておらず、異なるmessage_idに対してthanksがcreateされていた。

- 変更後
下記の内容で修正をおこなった。
app/views/thanks/thank_ajax.js.erb
```
$("<%= @id_name %>").html("<%= escape_javascript(render partial: 'thanks/thank', locals: {message: @message}) %>");
```

ファイル名：`app/views/thanks/_thank.haml`
.thank-ajax{:id => "thanks-btn-#{message.id}"}を追加。
それぞれのmessage.idに合わせてthank_ajax.js.erbが適切に当たるようにした。

```
.thank-ajax{:id => "thanks-btn-#{message.id}"}
    - if message.thank.blank? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
        .thanks-btn
            = link_to 'ありがとう', user_message_thanks_path(user_id: message.user_id, message_id: message.id), method: :post, remote: true
    - elsif message.thank.present? && message.user_id != current_user.id && message.chat_room.topic_create_user_id != message.user_id
        .thanks-btn-aledy
            = link_to '&#10003; ありがとう'.html_safe, user_message_thank_path(user_id: message.user_id, message_id: message.id, id: message.thank.id), method: :delete, remote: true

```

ファイル名：'app/controllers/thanks_controller.rb'
`render 'thank_ajax.js.erb'`された際にviewファイル側の`{:id => "thanks-btn-#{message.id}"}`と
thank_ajax.js.erb'中の`<%= @id_name %>`で２つのid名を合致させる必要があるため、`before_action :set_variables`で `@id_name = "#thanks-btn-#{@message.id}"`を実行し`thank_ajax.js.erb`に渡す。

```
class ThanksController < ApplicationController
~中略~
  before_action :set_variables

  def create
    Thank.create(user_id: params[:user_id], message_id: params[:message_id])
    render 'thank_ajax.js.erb'
  end

~中略~

  private
  def set_message
  def set_variables
    @message = Message.find(params[:message_id])
    @id_name = "#thanks-btn-#{@message.id}"
  end

end
```